### PR TITLE
Feature: Add Sidebar Theme Toggler and System Preference Default

### DIFF
--- a/modules/theme.js
+++ b/modules/theme.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 LupLab
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+class ThemeToggler {
+  themeToggler;
+  htmlElement;
+
+  constructor() {
+    /* Initialize DOM elements */
+    this.themeToggler = document.getElementById('theme-toggler');
+    this.htmlElement = document.documentElement;
+
+    /* Load and apply initial theme based on system settings */
+    this.applySystemTheme();
+
+    /* Attach event listener to theme toggler */
+    this.attachEventListeners();
+  }
+
+  /* Method to apply the system's preferred theme */
+  applySystemTheme() {
+    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    this.applyTheme(systemTheme);
+    this.themeToggler.checked = systemTheme === 'dark'; // Sync toggle with theme
+  }
+
+  /* Method to apply the theme */
+  applyTheme(theme) {
+    this.htmlElement.setAttribute('data-bs-theme', theme);
+  }
+
+  /* Method to toggle between light and dark themes */
+  toggleTheme() {
+    const newTheme = this.themeToggler.checked ? 'dark' : 'light';
+    this.applyTheme(newTheme);
+  }
+
+  /* Method to attach event listener for theme toggling */
+  attachEventListeners() {
+    this.themeToggler.addEventListener('change', () => this.toggleTheme());
+  }
+}
+
+/* Initialize Theme Toggler functionality after page load */
+window.addEventListener('DOMContentLoaded', () => {
+  new ThemeToggler();
+});

--- a/sample/template.html
+++ b/sample/template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="$lang$" xml:lang="$lang$"$if(dir)$ dir="$dir$"$endif$>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$lang$" xml:lang="$lang$"$if(dir)$ dir="$dir$"$endif$ data-bs-theme="light">
 <head>
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
@@ -47,6 +47,7 @@ $endif$
   <script src="$lbdir$/modules/mcq.js"></script>
   <script src="$lbdir$/modules/parsons.js"></script>
   <script src="$lbdir$/modules/hparsons.js"></script>
+  <script src="$lbdir$/modules/theme.js"></script>
 
   <link rel="stylesheet" href="$lbdir$/modules/lupbook.css"/>
   <link rel="stylesheet" href="$lbdir$/modules/fib.css"/>
@@ -112,6 +113,15 @@ $main-toc$
                 <i class="bi bi-terminal"></i>
                 <span class="ms-2">Show terminal</span>
               </button>
+            </li>
+          </ul>
+          <ul class="navbar-nav justify-content-end flex-grow-1 pe-3">
+            <li class="nav-item">
+              <label class="ps-0 form-check form-switch d-flex align-items-center">
+                <i class="bi bi-sun"></i>
+                <input id="theme-toggler" class="form-check-input ms-2 border border-primary rounded-pill shadow-none" type="checkbox" data-size="large">
+                <i class="bi bi-moon ms-2"></i>
+              </label>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
**This PR implements the following features:**

- Adds a theme toggler in the right sidebar, allowing users to easily switch between light and dark modes for the website.
- Sets the default theme to match the user's system preference upon page load.